### PR TITLE
Dev 4567 with Bugfixes

### DIFF
--- a/on-pull-request-runner/dist/discover-workspaces.js
+++ b/on-pull-request-runner/dist/discover-workspaces.js
@@ -26,7 +26,7 @@ async function main() {
         const outFile = artifactPath(`detect-language-${i}.json`);
         const containerOut = `/artifacts/detect-language-${i}.json`;
         const containerTarget = seed === '.' ? '/repo' : `/repo/${seed}`;
-        const { status, stderr } = dockerRun({
+        const { status, stderr } = await dockerRun({
             argv: [
                 'run',
                 '--rm',

--- a/on-pull-request-runner/dist/lib/docker.js
+++ b/on-pull-request-runner/dist/lib/docker.js
@@ -1,26 +1,54 @@
 /**
  * Docker CLI helpers for ORL image invocations.
  */
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 /**
  * Runs `docker` with the given args; does not throw on non-zero exit.
+ *
+ * Uses async `spawn` (not `spawnSync`) so callers in a `mapPool` can run
+ * concurrently without blocking the Node.js event loop.
+ *
+ * On timeout, kills the named Docker container via `docker kill` before
+ * sending SIGKILL to the CLI process — necessary because killing the CLI
+ * client does not stop the container managed by the Docker daemon.
  */
-export function dockerRun(args) {
-    const { argv, timeoutMs } = args;
-    const result = spawnSync('docker', argv, {
-        encoding: 'utf8',
-        maxBuffer: 50 * 1024 * 1024,
-        timeout: timeoutMs,
+export async function dockerRun(args) {
+    const { argv, timeoutMs, containerName } = args;
+    return new Promise((resolve) => {
+        const proc = spawn('docker', argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+        let stdout = '';
+        let stderr = '';
+        proc.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+        proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+        let timedOut = false;
+        let timer;
+        if (timeoutMs && timeoutMs > 0) {
+            timer = setTimeout(() => {
+                timedOut = true;
+                if (containerName) {
+                    try {
+                        execFileSync('docker', ['kill', containerName], { stdio: 'ignore' });
+                    }
+                    catch {
+                        // container already exited — ignore
+                    }
+                }
+                proc.kill('SIGKILL');
+            }, timeoutMs);
+        }
+        proc.on('close', (code) => {
+            clearTimeout(timer);
+            resolve({
+                status: timedOut ? 1 : (code ?? 1),
+                stdout,
+                stderr,
+            });
+        });
     });
-    return {
-        status: result.status ?? 1,
-        stdout: result.stdout ?? '',
-        stderr: result.stderr ?? '',
-    };
 }
 /** Like {@link dockerRun} but throws when exit status is non-zero. */
-export function dockerRunOrThrow(args) {
-    const { status, stderr, stdout } = dockerRun(args);
+export async function dockerRunOrThrow(args) {
+    const { status, stderr, stdout } = await dockerRun(args);
     if (status !== 0) {
         throw new Error(`docker ${args.argv.join(' ')} failed (${status}): ${stderr || stdout}`);
     }

--- a/on-pull-request-runner/dist/pull-rules.js
+++ b/on-pull-request-runner/dist/pull-rules.js
@@ -14,7 +14,7 @@ async function main() {
     const rulesUrl = requireEnv('RULES_SERVICE_URL');
     const channel = requireEnv('ORL_CHANNEL');
     const { uid, gid } = currentUidGid();
-    dockerRunOrThrow({
+    await dockerRunOrThrow({
         argv: [
             'run',
             '--rm',

--- a/on-pull-request-runner/dist/run-orl.js
+++ b/on-pull-request-runner/dist/run-orl.js
@@ -33,10 +33,13 @@ async function runBatch(args) {
     });
     const reportHost = path.join(workDir, '.orl', 'report.yaml');
     const { uid, gid } = currentUidGid();
-    const { status, stderr, stdout } = dockerRun({
+    const containerName = `gomboc-orl-${batch.batchId}`;
+    const { status, stderr, stdout } = await dockerRun({
         argv: [
             'run',
             '--rm',
+            '--name',
+            containerName,
             '--user',
             `${uid}:${gid}`,
             '-v',
@@ -57,6 +60,7 @@ async function runBatch(args) {
             '/workspace/.orl/report.yaml',
         ],
         timeoutMs,
+        containerName,
     });
     let report = null;
     if (fs.existsSync(reportHost)) {

--- a/on-pull-request-runner/src/discover-workspaces.ts
+++ b/on-pull-request-runner/src/discover-workspaces.ts
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
     const containerOut = `/artifacts/detect-language-${i}.json`;
     const containerTarget = seed === '.' ? '/repo' : `/repo/${seed}`;
 
-    const { status, stderr } = dockerRun({
+    const { status, stderr } = await dockerRun({
       argv: [
         'run',
         '--rm',

--- a/on-pull-request-runner/src/lib/docker.ts
+++ b/on-pull-request-runner/src/lib/docker.ts
@@ -1,37 +1,71 @@
 /**
  * Docker CLI helpers for ORL image invocations.
  */
-import { execFileSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawn } from 'node:child_process';
 
 export type DockerRunArgs = {
   argv: string[];
   timeoutMs?: number;
+  /** Container name passed via --name; used to docker-kill the container on timeout. */
+  containerName?: string;
 };
 
 /**
  * Runs `docker` with the given args; does not throw on non-zero exit.
+ *
+ * Uses async `spawn` (not `spawnSync`) so callers in a `mapPool` can run
+ * concurrently without blocking the Node.js event loop.
+ *
+ * On timeout, kills the named Docker container via `docker kill` before
+ * sending SIGKILL to the CLI process — necessary because killing the CLI
+ * client does not stop the container managed by the Docker daemon.
  */
-export function dockerRun(args: DockerRunArgs): {
+export async function dockerRun(args: DockerRunArgs): Promise<{
   status: number;
   stdout: string;
   stderr: string;
-} {
-  const { argv, timeoutMs } = args;
-  const result = spawnSync('docker', argv, {
-    encoding: 'utf8',
-    maxBuffer: 50 * 1024 * 1024,
-    timeout: timeoutMs,
+}> {
+  const { argv, timeoutMs, containerName } = args;
+
+  return new Promise((resolve) => {
+    const proc = spawn('docker', argv, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    let timedOut = false;
+    let timer: NodeJS.Timeout | undefined;
+
+    if (timeoutMs && timeoutMs > 0) {
+      timer = setTimeout(() => {
+        timedOut = true;
+        if (containerName) {
+          try {
+            execFileSync('docker', ['kill', containerName], { stdio: 'ignore' });
+          } catch {
+            // container already exited — ignore
+          }
+        }
+        proc.kill('SIGKILL');
+      }, timeoutMs);
+    }
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({
+        status: timedOut ? 1 : (code ?? 1),
+        stdout,
+        stderr,
+      });
+    });
   });
-  return {
-    status: result.status ?? 1,
-    stdout: result.stdout ?? '',
-    stderr: result.stderr ?? '',
-  };
 }
 
 /** Like {@link dockerRun} but throws when exit status is non-zero. */
-export function dockerRunOrThrow(args: DockerRunArgs): void {
-  const { status, stderr, stdout } = dockerRun(args);
+export async function dockerRunOrThrow(args: DockerRunArgs): Promise<void> {
+  const { status, stderr, stdout } = await dockerRun(args);
   if (status !== 0) {
     throw new Error(`docker ${args.argv.join(' ')} failed (${status}): ${stderr || stdout}`);
   }

--- a/on-pull-request-runner/src/pull-rules.ts
+++ b/on-pull-request-runner/src/pull-rules.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
   const channel = requireEnv('ORL_CHANNEL');
   const { uid, gid } = currentUidGid();
 
-  dockerRunOrThrow({
+  await dockerRunOrThrow({
     argv: [
       'run',
       '--rm',

--- a/on-pull-request-runner/src/run-orl.ts
+++ b/on-pull-request-runner/src/run-orl.ts
@@ -51,11 +51,14 @@ async function runBatch(args: RunBatchArgs): Promise<BatchResult> {
 
   const reportHost = path.join(workDir, '.orl', 'report.yaml');
   const { uid, gid } = currentUidGid();
+  const containerName = `gomboc-orl-${batch.batchId}`;
 
-  const { status, stderr, stdout } = dockerRun({
+  const { status, stderr, stdout } = await dockerRun({
     argv: [
       'run',
       '--rm',
+      '--name',
+      containerName,
       '--user',
       `${uid}:${gid}`,
       '-v',
@@ -76,6 +79,7 @@ async function runBatch(args: RunBatchArgs): Promise<BatchResult> {
       '/workspace/.orl/report.yaml',
     ],
     timeoutMs,
+    containerName,
   });
 
   let report: OrlReport | null = null;


### PR DESCRIPTION
Fixes:

**Bug 1** — spawnSync serialised mapPool workers
dockerRun used spawnSync, which blocks the Node.js event loop entirely. Even though mapPool spawns workers with async/await, spawnSync prevented any worker from resuming until the previous one finished. Effective concurrency was 1 regardless of ORL_REMEDIATE_CONCURRENCY. Symptom: batch timestamps spaced minutes apart instead of starting simultaneously.

**Bug 2** — timeout killed the CLI client, not the container
spawnSync's timeout option sends SIGKILL to the docker CLI process. The Docker daemon continues running the container independently, so the container kept running for its natural lifetime (10+ minutes) after the "timeout" fired. Subsequent batches started while the previous container was still consuming runner resources.